### PR TITLE
setup bundler in the rakefile

### DIFF
--- a/lib/templates/root/Rakefile.tt
+++ b/lib/templates/root/Rakefile.tt
@@ -1,4 +1,11 @@
 # encoding: UTF-8
+require 'rubygems'
+begin
+  require 'bundler/setup'
+rescue LoadError
+  puts 'You must `gem install bundler` and `bundle install` to run rake tasks'
+end
+
 require 'rake'
 require 'rake/rdoctask'
 require 'rake/gempackagetask'


### PR DESCRIPTION
Hi Guys,

Here is a small patch which sets up bundler in the rakefile, this makes sure that the correct rspec version is used if a user decides to use rspec.

I also noticed that there is a `require 'rake'` in the rakefile, I am not sure if this is needed as rake is already loaded and using the file, but I left it in there for now.

Let me know what you think,

Thanks

Josh 
