### PR TITLE
Require path

### DIFF
--- a/bin/enginex
+++ b/bin/enginex
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 # -*- mode: ruby -*-
 
-require 'enginex'
+require File.expand_path(File.join(*%w[.. .. lib enginex]), __FILE__)
+
 Enginex.start


### PR DESCRIPTION
Small change to tell the require where to look for enginex (so you can run bin/enginex and have it work correctly) and also using expand_path it's happy under 1.9.2. 

j
