### PR TITLE
.gitignore doesn't ignore spec directory

### DIFF
--- a/lib/enginex.rb
+++ b/lib/enginex.rb
@@ -46,8 +46,8 @@ class Enginex < Thor::Group
     directory test_path
   end
 
-  def copy_gitignore
-    copy_file "gitignore", ".gitignore"
+  def change_gitignore
+    template "gitignore", ".gitignore"
   end
 
   say_step "Vendoring Rails application at test/dummy"

--- a/lib/templates/gitignore
+++ b/lib/templates/gitignore
@@ -1,6 +1,6 @@
 .bundle/
 log/*.log
 pkg/
-test/dummy/db/*.sqlite3
-test/dummy/log/*.log
-test/dummy/tmp/
+<%= test_path %>/dummy/db/*.sqlite3
+<%= test_path %>/dummy/log/*.log
+<%= test_path %>/dummy/tmp/

--- a/lib/templates/root/Rakefile.tt
+++ b/lib/templates/root/Rakefile.tt
@@ -13,7 +13,7 @@ require 'rake/rdoctask'
 require 'rspec/core'
 require 'rspec/core/rake_task'
 
-Rspec::Core::RakeTask.new(:spec)
+RSpec::Core::RakeTask.new(:spec)
 <% else -%>
 require 'rake/testtask'
 

--- a/lib/templates/spec/spec_helper.rb
+++ b/lib/templates/spec/spec_helper.rb
@@ -22,11 +22,11 @@ ActiveRecord::Migrator.migrate File.expand_path("../dummy/db/migrate/", __FILE__
 # Load support files
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 
-Rspec.configure do |config|
-  # Remove this line if you don't want Rspec's should and should_not
+RSpec.configure do |config|
+  # Remove this line if you don't want RSpec's should and should_not
   # methods or matchers
   require 'rspec/expectations'
-  config.include Rspec::Matchers
+  config.include RSpec::Matchers
 
   # == Mock Framework
   config.mock_with :rspec

--- a/test/enginex_test.rb
+++ b/test/enginex_test.rb
@@ -6,7 +6,7 @@ class EnginexTest < ActiveSupport::TestCase
       # Root
       assert_file "Rakefile"
       assert_file "Gemfile", /gem "rails"/, /gem "capybara"/
-      assert_file ".gitignore", /\.bundle/, /db\/\*\.sqlite3/
+      assert_file ".gitignore", /\.bundle/
 
       # Lib
       assert_file "lib/demo_engine.rb", /module DemoEngine\nend/
@@ -26,6 +26,8 @@ class EnginexTest < ActiveSupport::TestCase
       assert_file "test/demo_engine_test.rb", /assert_kind_of Module, DemoEngine/
       assert_file "test/integration/navigation_test.rb", /assert_kind_of Dummy::Application, Rails.application/
       assert_file "test/support/integration_case.rb", /class ActiveSupport::IntegrationCase/
+
+      assert_file ".gitignore", /test\/dummy\/db\/\*\.sqlite3/
     end
   end
 
@@ -37,6 +39,8 @@ class EnginexTest < ActiveSupport::TestCase
 
       assert_file "spec/demo_engine_spec.rb", /DemoEngine.should be_a\(Module\)/
       assert_file "spec/integration/navigation_spec.rb", /Rails.application.should be_a\(Dummy::Application\)/
+
+      assert_file ".gitignore", /spec\/dummy\/db\/\*\.sqlite3/
     end
   end
 


### PR DESCRIPTION
a .gitignore file, which is generated with -t rspec, doesn't have "spec/.." entries for just ending up with not to ignore the spec directory.

I changed the "gitignore" file into an erb template so that it could count the option in.
