### PR TITLE
Show for the users that we are passing options to Rails app generator

### DIFF
--- a/lib/enginex.rb
+++ b/lib/enginex.rb
@@ -29,7 +29,17 @@ class Enginex < Thor::Group
 
   class_option :test_framework, :default => "test_unit", :aliases => "-t",
                                 :desc => "Test framework to use. test_unit or rspec."
-  
+  see_rails_text = "option passed to test Rails application generator, see 'rails new --help' for help"
+  class_option :"skip-active-record", :aliases => "-O", :desc => see_rails_text
+  class_option :"skip-prototype", :aliases => "-J", :desc => see_rails_text
+  class_option :edge, :desc => see_rails_text
+  class_option :dev, :desc => see_rails_text
+  class_option :template, :aliases => "-m", :desc => see_rails_text
+  class_option :builder, :aliases => "-b", :desc => see_rails_text
+  class_option :database, :aliases => "-d", :desc => see_rails_text
+  class_option :ruby, :aliases => "-r", :desc => see_rails_text
+  class_option :"skip-git", :aliases => "-G", :desc => see_rails_text
+
   desc "Creates a Rails 3 engine with Rakefile, Gemfile and running tests."
 
   say_step "Creating gem skeleton"

--- a/test/enginex_test.rb
+++ b/test/enginex_test.rb
@@ -62,4 +62,11 @@ class EnginexTest < ActiveSupport::TestCase
       assert_match /2 examples, 0 failures/, execute("rake spec")
     end
   end
+
+  test "enginex can pass options to rails application generator" do
+    run_enginex(:rspec, "-J -O") do
+      assert_no_file "spec/dummy/config/database.yml"
+      assert_no_file "spec/dummy/public/javascripts/prototype.js"
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -22,7 +22,7 @@ $:.unshift LIB_PATH
 require 'enginex'
 
 class ActiveSupport::TestCase
-  def run_enginex(suite = :test_unit)
+  def run_enginex(suite = :test_unit, rails_options="")
     if suite == :rspec
       option = '--test-framework=rspec'
     else
@@ -30,7 +30,7 @@ class ActiveSupport::TestCase
     end
 
     $counter += 1
-    `ruby -I#{LIB_PATH} -rrubygems #{BIN_PATH} #{destination_root} #{option}`
+    `ruby -I#{LIB_PATH} -rrubygems #{BIN_PATH} #{destination_root} #{option} #{rails_options}`
     yield
     FileUtils.rm_rf(File.dirname(destination_root))
   rescue Exception => e


### PR DESCRIPTION
Hi,

not sure if it's needed, but if you want to skip Prototype or ActiveRecord when generating test app for engine, you can do "enginex engine_name -J -O" and these options, among others, will be properly passed to Rails application generator.

I have added test for this behavior, assuming it's correct, and information to "enginex --help" that we are accepting those. I have listed only those that make sense when generating test application in help listing.

Let me know if it's any use,
H.
