### PR TITLE
Ensure there's an authors field or the gem fails to build.

### DIFF
--- a/lib/templates/root/%underscored%.gemspec.tt
+++ b/lib/templates/root/%underscored%.gemspec.tt
@@ -6,4 +6,5 @@ Gem::Specification.new do |s|
   s.description = "Insert <%= camelized %> description."
   s.files = Dir["{app,lib,config}/**/*"] + ["MIT-LICENSE", "Rakefile", "Gemfile", "README.rdoc"]
   s.version = "0.0.1"
+  s.authors = "Author name here."
 end


### PR DESCRIPTION
Rubygems 1.8.5 will fail to build the gem without an authors section in the gemspec.  Update this to add this field.  The absence of this causes a failing test on master.
