### PR TITLE
Fix #28 Project Name with Hyphen

### DIFF
--- a/lib/enginex.rb
+++ b/lib/enginex.rb
@@ -124,7 +124,7 @@ class Enginex < Thor::Group
     end
 
     def camelized
-      @camelized ||= name.camelize
+      @camelized ||= name.underscore.camelize
     end
 
     def underscored


### PR DESCRIPTION
- Camelize does not work properly if the target string contains hyphens. Use
  the underscore method to convert hyphens before calling camelize.
