### PR TITLE
Added git credentials to gemspec

### DIFF
--- a/lib/enginex.rb
+++ b/lib/enginex.rb
@@ -130,4 +130,14 @@ class Enginex < Thor::Group
     def underscored
       @underscored ||= name.underscore
     end
+    
+    def author_name
+      @git_author_name ||= `git config user.name`.chomp
+      @author_name ||= @git_author_name.empty? ? 'Author name here.' : @git_author_name
+    end
+    
+    def author_email
+      @git_author_email ||= `git config user.email`.chomp
+      @author_email ||= @git_author_email.empty? ? 'Author email here.' : @git_author_email
+    end
 end

--- a/lib/templates/root/%underscored%.gemspec.tt
+++ b/lib/templates/root/%underscored%.gemspec.tt
@@ -6,5 +6,6 @@ Gem::Specification.new do |s|
   s.description = "Insert <%= camelized %> description."
   s.files = Dir["{app,lib,config}/**/*"] + ["MIT-LICENSE", "Rakefile", "Gemfile", "README.rdoc"]
   s.version = "0.0.1"
-  s.authors = "Author name here."
+  s.authors = "<%= author_name %>"
+  s.email   = "<%= author_email %>"
 end


### PR DESCRIPTION
Fills out gem's author name and email `automagically` using git credentials.
