### PR TITLE
replacement.

### DIFF
--- a/lib/templates/root/Rakefile.tt
+++ b/lib/templates/root/Rakefile.tt
@@ -7,7 +7,7 @@ rescue LoadError
 end
 
 require 'rake'
-require 'rake/rdoctask'
+require 'rake/rdoc/task'
 
 <% if rspec? -%>
 require 'rspec/core'


### PR DESCRIPTION
i caught this warning about the 'require 'rake/rdoctask'' is deprecated. I've replaced that for 'require 'rdoc/task'
