### PR TITLE
Fix Capybara deprecation warning

### DIFF
--- a/lib/templates/test/support/integration_case.rb
+++ b/lib/templates/test/support/integration_case.rb
@@ -1,5 +1,5 @@
 # Define a bare test case to use with Capybara
 class ActiveSupport::IntegrationCase < ActiveSupport::TestCase
-  include Capybara
+  include Capybara::DSL
   include Rails.application.routes.url_helpers
 end


### PR DESCRIPTION
`include Capybara` is deprecated please use `include Capybara::DSL` instead.

So do I :)
