### PR TITLE
Updated source to https://rubygems.org to suppress security related warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source "https://rubygems.org"
 
 gemspec
 

--- a/lib/templates/root/Gemfile.tt
+++ b/lib/templates/root/Gemfile.tt
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 gem "rails", "<%= ActiveSupport::VERSION::STRING %>"
 gem "capybara", ">= 0.4.0"


### PR DESCRIPTION
Changed source :rubygems to https://rubygems.org
